### PR TITLE
Add common crates with explicit versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+sysinfo = "0.30"
+walkdir = "2.5"
+sha2 = "0.10"
+md5 = "0.7"
+sha1 = "0.10"
+flate2 = "1.0"
+reqwest = { version = "0.11", features = ["json"] }

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install system packages required for building Rust projects
+sudo apt-get update
+sudo apt-get install -y build-essential pkg-config libssl-dev curl git
+
+# Ensure rustup is installed
+if ! command -v rustup >/dev/null 2>&1; then
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+# Update toolchain and install common components
+rustup update
+rustup component add clippy rustfmt
+
+# Pre-fetch Rust dependencies so later steps can run offline
+cargo fetch --locked


### PR DESCRIPTION
## Summary
- add serde, serde_json, clap, sysinfo, walkdir, sha2, md5, sha1, flate2 and reqwest with pinned versions

## Testing
- `cargo test --quiet` *(fails: could not connect to crates.io)*
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' is not installed)*
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*